### PR TITLE
fix: Fixed misleading STDERR log when output being sent to STDOUT

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,9 +94,9 @@ export async function renderHandlebarsTemplate(files, outputDirectory = process.
       await process.stdout.write(htmlContents, 'utf8');
     } else {
       await writeFile(path, htmlContents, 'utf8');
+      debug(`Wrote ${path}`);
+      console.error(`Wrote ${path} from ${file}`);
     }
-    debug(`Wrote ${path}`);
-    console.error(`Wrote ${path} from ${file}`);
   }));
 }
 


### PR DESCRIPTION
When you instruct the application to redirect output to STDOUT (as in `hbs -s -D data.json template.hbs`) you still get a stray debug message written to STDERR saying that the output was written to file. This is misleading and potentially problematic in pipelined scenarios (e.g. if you wanted `hbs -s ... 2>&1 > output.json && something-else.sh < output.json`)