### PR TITLE
feat: use mkdirp to create folder before outputing

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "handlebars": "^4.0.5",
     "lodash.merge": "^3.3.2",
     "minimist": "^1.2.0",
+    "mkdirp-promise": "^5.0.1",
     "resolve": "^1.1.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "handlebars": "^4.0.5",
     "lodash.merge": "^3.3.2",
     "minimist": "^1.2.0",
-    "mkdirp-promise": "^5.0.1",
+    "mkdirp-then": "^1.2.0",
     "resolve": "^1.1.6"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import packageJson from '../package.json';
 import resolveNode from 'resolve';
 import { readFile, writeFile } from 'fs-promise';
 import merge from 'lodash.merge';
+import mkdirp from 'mkdirp-promise';
 const debug = require('debug')('hbs');
 function resolve(file, options) {
   return new Promise((resolvePromise, reject) => resolveNode(file, options, (error, path) => {
@@ -95,6 +96,7 @@ export async function renderHandlebarsTemplate(
     if (stdout) {
       await process.stdout.write(htmlContents, 'utf8');
     } else {
+      await mkdirp(outputDirectory);
       await writeFile(path, htmlContents, 'utf8');
       debug(`Wrote ${path}`);
       console.error(`Wrote ${path} from ${file}`);

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import packageJson from '../package.json';
 import resolveNode from 'resolve';
 import { readFile, writeFile } from 'fs-promise';
 import merge from 'lodash.merge';
-import mkdirp from 'mkdirp-promise';
+import mkdirp from 'mkdirp-then';
 const debug = require('debug')('hbs');
 function resolve(file, options) {
   return new Promise((resolvePromise, reject) => resolveNode(file, options, (error, path) => {


### PR DESCRIPTION
By default, `writeFile` will not create the output directory if it does not exist and, as such, will cause an error to be thrown when it doesn't. This is a nuisance because dist folder are usually not commited to the repository so you either have to create the folder structure and commit it with a `.gitignore` file, or run a script to create these folders pre-build.

Using [`mkdirp-promise`](https://github.com/ahmadnassri/mkdirp-promise) to create the folder solves the problem. This PR does just that.