### PR TITLE
adds an option to accept data directly from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ Usage:
   -h, --help                 output usage information
   -v, --version              output the version number
   -o, --output <directory>   Directory to output rendered templates, defaults to cwd
-  -P, --partial <glob>...    Register a partial* (use as many of these as you want)
-  -H, --helper <glob>...     Register a helper* (use as many of these as you want)
-  -D, --data <glob|json>...  Parse some data*
+  -e, --extension            Output extension of generated files, defaults to html
+  -s, --stdout               Output to standard output
+  -i, --stdin                Receive data directly from stdin
+  -P, --partial <glob>...    Register a partial (use as many of these as you want)
+  -H, --helper <glob>...     Register a helper (use as many of these as you want)
+
+  -D, --data <glob|json>...  Parse some data
 
 Examples:
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "prepublish": "babel src -d lib",
     "pretest": "npm run lint",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "test": "npm run test:run:1 && npm run test:verify:1 && npm run test:run:2 && npm run test:verify:2",
+    "test": "npm run test:run:1 && npm run test:verify:1 && npm run test:run:2 && npm run test:verify:2 && npm run test:run:3 && npm run test:verify:3",
     "test:run:1": "node . -H handlebars-helper-br -D ./test/data.json -o test test/test-1.hbs",
     "test:verify:1": "diff test/test-1.html test/verify-1.html",
     "test:run:2": "node . -s -H handlebars-helper-br -D ./test/data.json test/test-1.hbs > test/test-2.html",
     "test:verify:2": "diff test/test-2.html test/verify-1.html",
+    "test:run:3": "cat ./test/data.json | node . -s -H handlebars-helper-br --stdin test/test-1.hbs > test/test-3.html",
+    "test:verify:3": "diff test/test-3.html test/verify-1.html",
     "watch": "npm run prepublish -- -w"
   },
   "config": {
@@ -55,6 +57,7 @@
     "babel-runtime": "^5.8.34",
     "debug": "^2.2.0",
     "fs-promise": "^0.3.1",
+    "get-stdin": "^8.0.0",
     "glob-promise": "^1.0.4",
     "handlebars": "^4.0.5",
     "lodash.merge": "^3.3.2",


### PR DESCRIPTION
Closes #54

Adds an option to receive data from stdin directly.

## example

```sh
$ echo '{"test":123}' | hbs --stdin --stdout template.hbs
```

_template.hbs_
```handlebars
*{{test}}*
```

_output_
```
*123*
```